### PR TITLE
fix addMonth bug

### DIFF
--- a/lib/src/date/src/jalali/jalali_date.dart
+++ b/lib/src/date/src/jalali/jalali_date.dart
@@ -475,8 +475,10 @@ class Jalali implements Date, Comparable<Jalali> {
       final int mod = sum % 12;
       // can not use "sum ~/ 12" directly
       final int deltaYear = (sum - mod) ~/ 12;
-
-      return Jalali(year + deltaYear, mod + 1, day);
+      final int newMonth = mod + 1;
+      final int newMonthLength = Jalali(year + deltaYear, newMonth).monthLength;
+      final int newDay = day <= newMonthLength ? day : newMonthLength;
+      return Jalali(year + deltaYear, newMonth, newDay);
     }
   }
 


### PR DESCRIPTION
In this fixed bug, when adding a month to the previous month and the day is equal to a day that does not exist in the new month, for example, 30 days in Esfand, it caused an error 'Jalali day is out of valid range.' By setting it equal to the maximum day of that month, the bug was fixed.