### PR TITLE
feat: add holiday support to Persian date picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.2.0
+* [FEATURE] Add holiday configuration support to Persian date picker
 ## 3.1.1
 * [FIX] Fix incompatible with flutter 3.35.1.
 ## 3.1.0

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Jalali? picked = await showPersianDatePicker(
   initialDate: Jalali.now(),
   firstDate: Jalali(1385, 8),
   lastDate: Jalali(1450, 9),
+  holidayConfig: PersianHolidayConfig(
+    weekendDays: {7}
+  ),
   initialEntryMode:
       PersianDatePickerEntryMode.calendarOnly,
   initialDatePickerMode: PersianDatePickerMode.year,
@@ -149,7 +152,7 @@ Jalali? pickedDate = await showModalBottomSheet<Jalali>(
                   ),
                   onPressed: () {
                     print(
-                        tempPickedDate ?? Jal
+                        tempPickedDate ?? Jalali.now());
                     Navigator.of(context).pop(
                         tempPickedDate ?? Jalali.now());
                   },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -126,6 +126,9 @@ class _HomePageState extends State<HomePage> {
                           initialEntryMode:
                               PersianDatePickerEntryMode.calendarOnly,
                           initialDatePickerMode: PersianDatePickerMode.year,
+                          holidayConfig: PersianHolidayConfig(
+                            weekendDays: {7}
+                          ),
                         );
                         if (picked != null &&
                             picked.toJalaliDateTime() != selectedDate) {

--- a/lib/src/material/date.dart
+++ b/lib/src/material/date.dart
@@ -5,6 +5,9 @@
 import 'package:flutter/material.dart';
 import 'package:shamsi_date/shamsi_date.dart';
 
+/// Callback to determine if a given date is a holiday
+typedef PersianHolidayPredicate = bool Function(Jalali date);
+
 /// Utility functions for working with dates.
 abstract final class PersianDateUtils {
   /// Returns a [Jalali] with the date of the original, but time set to
@@ -244,6 +247,59 @@ class JalaliRange {
 
   @override
   String toString() => '$start - $end';
+}
+
+/// Configuration for holiday dates.
+///
+/// This class is used to specify dates that are holidays.
+class PersianHolidayConfig {
+  /// Specific dates that are holidays
+  final Set<Jalali>? specificDates;
+
+  /// Weekdays that are holidays (1 = Saturday, 7 = Friday)
+  /// In Persian calendar: 7 = Friday (Jomeh)
+  final Set<int>? weekendDays;
+
+  /// Custom predicate for complex holiday logic
+  final PersianHolidayPredicate? customPredicate;
+
+  /// Color for holiday dates
+  final Color holidayColor;
+
+  /// Whether holidays are selectable
+  final bool holidaysSelectable;
+
+  const PersianHolidayConfig({
+    this.specificDates,
+    this.weekendDays,
+    this.customPredicate,
+    this.holidayColor = Colors.red,
+    this.holidaysSelectable = true,
+  });
+
+  /// Check if a date is a holiday
+  bool isHoliday(Jalali date) {
+    // Check specific dates
+    if (specificDates != null) {
+      for (final holiday in specificDates!) {
+        if (PersianDateUtils.isSameDay(date, holiday)) {
+          return true;
+        }
+      }
+    }
+
+    // Check weekend days (1 = Saturday, 7 = Friday)
+    if (weekendDays != null && weekendDays!.contains(date.weekDay % 8)) {
+      return true;
+    }
+
+    // Check custom predicate
+    if (customPredicate != null && customPredicate!(date)) {
+      return true;
+    }
+
+    return false;
+  }
 }
 
 extension JalaliExt on Jalali {

--- a/lib/src/material/date_picker.dart
+++ b/lib/src/material/date_picker.dart
@@ -163,6 +163,7 @@ Future<Jalali?> showPersianDatePicker({
   String? fieldLabelText,
   TextInputType? keyboardType,
   Offset? anchorPoint,
+  PersianHolidayConfig? holidayConfig,
   final ValueChanged<PersianDatePickerEntryMode>? onDatePickerModeChange,
   final Icon? switchToInputEntryModeIcon,
   final Icon? switchToCalendarEntryModeIcon,
@@ -211,6 +212,7 @@ Future<Jalali?> showPersianDatePicker({
     onDatePickerModeChange: onDatePickerModeChange,
     switchToInputEntryModeIcon: switchToInputEntryModeIcon,
     switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
+    holidayConfig: holidayConfig,
   );
 
   if (textDirection != null) {
@@ -280,6 +282,7 @@ class DatePickerDialog extends StatefulWidget {
     this.onDatePickerModeChange,
     this.switchToInputEntryModeIcon,
     this.switchToCalendarEntryModeIcon,
+    this.holidayConfig,
   }) : initialDate = initialDate == null
            ? null
            : PersianDateUtils.dateOnly(initialDate),
@@ -364,6 +367,9 @@ class DatePickerDialog extends StatefulWidget {
   /// If this is null, it will default to the words representing the date format
   /// string. For example, 'Month, Day, Year' for en_US.
   final String? fieldLabelText;
+
+  /// Holiday configuration
+  final PersianHolidayConfig? holidayConfig;
 
   /// {@template flutter.material.datePickerDialog}
   /// The keyboard type of the [TextField].
@@ -591,6 +597,7 @@ class _DatePickerDialogState extends State<DatePickerDialog>
         onDateChanged: _handleDateChanged,
         selectableDayPredicate: widget.selectableDayPredicate,
         initialCalendarMode: widget.initialCalendarMode,
+        holidayConfig: widget.holidayConfig,
       );
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: persian_datetime_picker
 description: A persian (farsi,shamsi,jalali) datetime picker for flutter, inspired by material datetime picker.
-version: 3.1.1
+version: 3.2.0
 
 homepage: https://github.com/M-amir-M/persian-datetime-picker
 


### PR DESCRIPTION
This PR adds comprehensive holiday marking functionality to the Persian calendar date picker (material), allowing developers to visually distinguish and optionally disable holidays, weekends, and special dates.

### Holiday config
```dart
holidayConfig: PersianHolidayConfig(
  weekendDays: {7}, // Friday
  specificDates: {Jalali(1404, 1, 1)}, // Nowruz
  holidayColor: Colors.red,
  holidaysSelectable: true,
),
```

### Full example:
```dart
Jalali? picked = await showPersianDatePicker(
  context: context,
  initialDate: Jalali.now(),
  firstDate: Jalali(1385, 8),
  lastDate: Jalali(1450, 9),
  initialEntryMode:
    PersianDatePickerEntryMode.calendarOnly,
  initialDatePickerMode: PersianDatePickerMode.year,
  // New feature
  holidayConfig: PersianHolidayConfig(
    weekendDays: {7}
  ),
);
```

<img width="351" height="528" alt="Persian datetime picker with holiday" src="https://github.com/user-attachments/assets/f19e4ace-94af-4ebd-b59f-e71eaf11cb30" />
